### PR TITLE
Add an onerror handler to shutil.rmtree calls

### DIFF
--- a/tick_my_feedstocks.py
+++ b/tick_my_feedstocks.py
@@ -85,6 +85,7 @@ import argparse
 import os
 import re
 import shutil
+import stat
 import tempfile
 from base64 import b64encode
 from collections import defaultdict
@@ -547,7 +548,7 @@ def regenerate_fork(fork):
     if not r.is_dirty():
         # No changes made during regeneration.
         # Clean up and return
-        shutil.rmtree(working_dir)
+        shutil.rmtree(working_dir, onerror=remove_readonly)
         return False
 
     commit_msg = \
@@ -558,8 +559,13 @@ def regenerate_fork(fork):
                    author=Actor(fork.owner.login, fork.owner.email))
     r.git.push()
 
-    shutil.rmtree(working_dir)
+    shutil.rmtree(working_dir, onerror=remove_readonly)
     return True
+
+
+def remove_readonly(func, path, excinfo):
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 
 def tick_feedstocks(gh_password=None,

--- a/tick_my_feedstocks.py
+++ b/tick_my_feedstocks.py
@@ -90,8 +90,6 @@ import tempfile
 from base64 import b64encode
 from collections import defaultdict
 from collections import namedtuple
-import conda_smithy
-import conda_smithy.configure_feedstock
 from git import Actor
 from git import Repo
 from github import Github
@@ -537,6 +535,9 @@ def regenerate_fork(fork):
     :param github.Repository.Repository fork: fork of conda-forge feedstock
     :return: `bool` -- True if regenerated, false otherwise
     """
+    import conda_smithy
+    import conda_smithy.configure_feedstock
+
     # Would need me to pass gh_user, gh_password
     # subprocess.run(["./renderer.sh", gh_user, gh_password, fork.name])
 


### PR DESCRIPTION
Should avoid errors such as
`PermissionError: [WinError 5] Access is denied: 'C:\\Users\\akelman\\AppData\\Local\\Temp\\tmpu3fwwzf4\\botocore-feedstock\\.git\\objects\\pack\\pack-75b2092341bff03adcd15b32b752762b5801440f.idx'`

same as https://github.com/conda-forge/conda-forge.github.io/pull/523 but applied to the develop branch here